### PR TITLE
fix: update to Node.js 22

### DIFF
--- a/cdk/TestStack.ts
+++ b/cdk/TestStack.ts
@@ -27,7 +27,7 @@ export class TestStack extends Stack {
 				hash: layer.hash,
 			}).code,
 			compatibleArchitectures: [Lambda.Architecture.ARM_64],
-			compatibleRuntimes: [Lambda.Runtime.NODEJS_20_X],
+			compatibleRuntimes: [Lambda.Runtime.NODEJS_22_X],
 		})
 
 		const lambda = new PackedLambdaFn(this, 'fn', lambdaSources.test, {

--- a/src/PackedLambdaFn.ts
+++ b/src/PackedLambdaFn.ts
@@ -44,7 +44,7 @@ export class PackedLambdaFn extends Construct {
 
 		this.fn = new Lambda.Function(this, 'fn', {
 			architecture: Lambda.Architecture.ARM_64,
-			runtime: props.runtime ?? Lambda.Runtime.NODEJS_20_X,
+			runtime: props.runtime ?? Lambda.Runtime.NODEJS_22_X,
 			timeout: Duration.seconds(5),
 			memorySize: 1792,
 			environment: {


### PR DESCRIPTION
See https://aws.amazon.com/de/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/
